### PR TITLE
Complete issue #9

### DIFF
--- a/budget_buddy/lib/dialogs/add_dialog.dart
+++ b/budget_buddy/lib/dialogs/add_dialog.dart
@@ -4,7 +4,6 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:budget_buddy/widgets/buttons.dart';
-import 'package:budget_buddy/main.dart';
 
 // adapted from to-dont-list code
 typedef ItemsListChangedCallback = Function(Item item);
@@ -151,7 +150,6 @@ class _ItemDialogState extends State<ItemDialog> {
                     payment: amount,
                     image: img,
                     frequency: dropdownValue));
-                setBalance(getBalance()+ amount);    
                 Navigator.pop(context);
               });
             },

--- a/budget_buddy/lib/dialogs/info_dialog.dart
+++ b/budget_buddy/lib/dialogs/info_dialog.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:money_formatter/money_formatter.dart';
 import 'package:budget_buddy/widgets/buttons.dart';
-import 'package:budget_buddy/main.dart';
 
 typedef ItemsListDeletedCallback = Function(Item item);
 
@@ -126,7 +125,6 @@ class _DeleteDialogState extends State<DeleteDialog> {
             key: const Key("Delete"),
             child: const Text('Yes'),
             onPressed: () {
-              setBalance(getBalance() - widget.item.payment);
               widget.onDeleteItem(widget.item);
               Navigator.pop(context);
               Navigator.pop(context);

--- a/budget_buddy/lib/main.dart
+++ b/budget_buddy/lib/main.dart
@@ -5,8 +5,6 @@ import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 
-double totalBalance = 150.00;
-
 Future<void> main() async {
   // Ensure that plugin services are initialized so that `availableCameras()`
   // can be called before `runApp()`
@@ -75,74 +73,102 @@ class MainNavigatorState extends State<MainNavigator> {
   void _handleNewItem(Item item) {
     setState(() {
       items.add(item);
-      if (item.frequency == "Daily") {
-        int i = 1;
-        while (i < 365) {
-          Item newItem = Item(
-              name: item.name,
-              date: item.date,
-              frequency: item.frequency,
-              payment: item.payment);
-          DateTime newDate =
-              DateTime(item.date!.year, item.date!.month, item.date!.day + (i));
-          newItem.date = newDate;
-          items.add(newItem);
-          i++;
-        }
-      }
-      if (item.frequency == "Weekly") {
-        int i = 1;
-        while (i < 52) {
-          Item newItem = Item(
-              name: item.name,
-              date: item.date,
-              frequency: item.frequency,
-              payment: item.payment);
-          DateTime newDate = DateTime(
-              item.date!.year, item.date!.month, item.date!.day + (7 * i));
-          newItem.date = newDate;
-          items.add(newItem);
-          i++;
-        }
-      }
-      if (item.frequency == "Biweekly") {
-        int i = 1;
-        while (i < 26) {
-          Item newItem = Item(
-              name: item.name,
-              date: item.date,
-              frequency: item.frequency,
-              payment: item.payment);
-          DateTime newDate = DateTime(
-              item.date!.year, item.date!.month, item.date!.day + (14 * i));
-          newItem.date = newDate;
-          items.add(newItem);
-          i++;
-        }
-      }
-      if (item.frequency == "Monthly") {
-        int i = 1;
-        while (i < 12) {
-          Item newItem = Item(
-              name: item.name,
-              date: item.date,
-              frequency: item.frequency,
-              payment: item.payment);
-          DateTime newDate =
-              DateTime(item.date!.year, item.date!.month + i, item.date!.day);
-          newItem.date = newDate;
-          items.add(newItem);
-          i++;
-        }
-      }
-      items.sort((a, b) => a.date!.compareTo(b.date!));
+      _updateRecurringItems();
+    //   if (item.frequency == "Daily") {
+    //     int i = 1;
+    //     while (i < 365) {
+    //       Item newItem = Item(
+    //           name: item.name,
+    //           date: item.date,
+    //           frequency: item.frequency,
+    //           payment: item.payment);
+    //       DateTime newDate =
+    //           DateTime(item.date!.year, item.date!.month, item.date!.day + (i));
+    //       newItem.date = newDate;
+    //       items.add(newItem);
+    //       i++;
+    //     }
+    //   }
+    //   if (item.frequency == "Weekly") {
+    //     int i = 1;
+    //     while (i < 52) {
+    //       Item newItem = Item(
+    //           name: item.name,
+    //           date: item.date,
+    //           frequency: item.frequency,
+    //           payment: item.payment);
+    //       DateTime newDate = DateTime(
+    //           item.date!.year, item.date!.month, item.date!.day + (7 * i));
+    //       newItem.date = newDate;
+    //       items.add(newItem);
+    //       i++;
+    //     }
+    //   }
+    //   if (item.frequency == "Biweekly") {
+    //     int i = 1;
+    //     while (i < 26) {
+    //       Item newItem = Item(
+    //           name: item.name,
+    //           date: item.date,
+    //           frequency: item.frequency,
+    //           payment: item.payment);
+    //       DateTime newDate = DateTime(
+    //           item.date!.year, item.date!.month, item.date!.day + (14 * i));
+    //       newItem.date = newDate;
+    //       items.add(newItem);
+    //       i++;
+    //     }
+    //   }
+    //   if (item.frequency == "Monthly") {
+    //     int i = 1;
+    //     while (i < 12) {
+    //       Item newItem = Item(
+    //           name: item.name,
+    //           date: item.date,
+    //           frequency: item.frequency,
+    //           payment: item.payment);
+    //       DateTime newDate =
+    //           DateTime(item.date!.year, item.date!.month + i, item.date!.day);
+    //       newItem.date = newDate;
+    //       items.add(newItem);
+    //       i++;
+    //     }
+    //   }
+    //   items.sort((a, b) => a.date!.compareTo(b.date!));
     });
   }
 
   void _handleDeleteItem(Item item) {
     setState(() {
       items.remove(item);
+      if (item.frequency != null) {
+        _updateRecurringItems();
+      }
     });
+  }
+
+  void _handleCompleteItem(Item item) {
+    setState(() {
+      item.isComplete = true;
+      if (item.frequency != null) {
+        DateTime? nextDate = item.getNextDate();
+        if (nextDate != null) {
+          items.add(item.copyWithNewDate(nextDate));
+        }
+      }
+      items.sort((a, b) => a.date!.compareTo(b.date!));
+    });
+  }
+
+  void _updateRecurringItems() {
+    final now = DateTime.now();
+    
+    // Remove completed items
+    items.removeWhere((item) => 
+      item.isComplete && item.date!.isBefore(now.subtract(const Duration(days: 30)))
+    );
+
+    items.sort((a, b) => a.date!.compareTo(b.date!));
   }
 
   List<Item> _getItemsForSelectedDay(DateTime day) {
@@ -151,14 +177,15 @@ class MainNavigatorState extends State<MainNavigator> {
 
   @override
   void initState() {
-    items = [
-      Item(
-          name: "Bill 5",
-          date: DateTime.now(),
-          payment: 150.0,
-          frequency: "Monthly")
-    ];
+    // items = [
+    //   Item(
+    //       name: "Bill 5",
+    //       date: DateTime(2024, 11, 10),
+    //       payment: 150.0,
+    //       frequency: "Monthly")
+    // ];
     super.initState();
+    _updateRecurringItems(); 
   }
 
   Widget returnScreen(int screenIndex) {
@@ -171,6 +198,7 @@ class MainNavigatorState extends State<MainNavigator> {
         selectedDay: selectedDay,
         onListChanged: _handleNewItem,
         onDeleteItem: _handleDeleteItem,
+        onCompleteItem: _handleCompleteItem,
         cam: widget.camera,
         onDaySelected: (selectedDay, focusedDay) {
           setState(() {
@@ -186,7 +214,8 @@ class MainNavigatorState extends State<MainNavigator> {
               : items,
           onListChanged: _handleNewItem,
           cam: widget.camera,
-          onDeleteItem: _handleDeleteItem);
+          onDeleteItem: _handleDeleteItem,
+          onCompleteItem: _handleCompleteItem);
     }
   }
 
@@ -209,13 +238,6 @@ class MainNavigatorState extends State<MainNavigator> {
           selectedItemColor: Colors.green,
         ));
   }
-}
- double getBalance(){
-  return totalBalance;
-
-}
-void setBalance(double i){
-  totalBalance = i;
 }
 // class MyHomePage extends StatefulWidget {
 //   const MyHomePage({super.key, required this.title});

--- a/budget_buddy/lib/objects/item.dart
+++ b/budget_buddy/lib/objects/item.dart
@@ -6,11 +6,64 @@ class Item {
   double payment = 0.0;
   String? frequency;
   XFile? image;
+  bool isComplete = false; 
+  DateTime? originalDate;
 
   Item(
       {required this.name,
       required this.date,
       required this.payment,
       this.image,
-      this.frequency});
+      this.frequency
+    }) {
+    originalDate = date;  // Initialize originalDate in constructor
+  }
+
+  Item copyWithNewDate(DateTime newDate) {
+    return Item(
+      name: name,
+      date: newDate,
+      payment: payment,
+      frequency: frequency,
+      image: image,
+    );
+  }
+
+  DateTime? getNextDate() {
+    if (date == null || frequency == null) return null;
+    
+    switch (frequency) {
+      case "Daily":
+        return date!.add(const Duration(days: 1));
+      case "Weekly":
+        return date!.add(const Duration(days: 7));
+      case "Biweekly":
+        return date!.add(const Duration(days: 14));
+      case "Monthly":
+        return DateTime(
+          date!.year,
+          date!.month + 1,
+          date!.day
+        );
+      default:
+        return null;
+    }
+  }
+
+  List<DateTime> getFutureOccurrences() {
+    List<DateTime> dates = [];
+    if (frequency == null) return dates;
+
+    DateTime? currentDate = date;
+    // Calculate next 12 months of occurrences
+    for(int i = 0; i < 12; i++) {
+      if (currentDate != null) {
+        print("Calculating occurrence: ${currentDate.toString()}");
+        dates.add(currentDate);
+        currentDate = getNextDate();
+      }
+    }
+    print("Found ${dates.length} future occurrences");
+    return dates;
+  }
 }

--- a/budget_buddy/lib/pages/item_list_view.dart
+++ b/budget_buddy/lib/pages/item_list_view.dart
@@ -4,7 +4,6 @@ import 'package:budget_buddy/objects/item.dart';
 import 'package:budget_buddy/pages/delete_items.dart';
 import 'package:budget_buddy/widgets/budget_item.dart';
 import 'package:flutter/material.dart';
-import 'package:budget_buddy/main.dart';
 
 typedef ItemsListChangedCallback = Function(Item item);
 typedef ItemsListDeletedCallback = Function(Item item);
@@ -15,11 +14,13 @@ class ItemListView extends StatefulWidget {
       required this.items,
       required this.onListChanged,
       required this.onDeleteItem,
+      required this.onCompleteItem,
       required this.cam});
 
   final List<Item> items;
   final ItemsListChangedCallback onListChanged;
   final ItemsListDeletedCallback onDeleteItem;
+  final Function(Item) onCompleteItem;
   final cam;
 
   @override
@@ -29,29 +30,48 @@ class ItemListView extends StatefulWidget {
 }
 
 class ItemListViewState extends State<ItemListView> {
+  bool showCompleted = false;
+
   @override
   Widget build(BuildContext context) {
-    String totalStr = getBalance().toStringAsFixed(2);
+    final displayedItems = widget.items.where((item) => 
+      item.isComplete == showCompleted
+    ).toList();
+
     return Scaffold(
       appBar: AppBar(
-          title:  Row(
-            children: <Widget>[
-                Text(
-                'Budget Buddy',
-                ),
-                Spacer(),
-              Text("My Bills: \$$totalStr"),
-            ]
-           )
+        title: const Text("Budget Buddy"),
+        centerTitle: true,
+        actions: [
+          // Toggle completed button
+          TextButton.icon(
+            onPressed: () {
+              setState(() {
+                showCompleted = !showCompleted;
+              });
+            },
+            icon: Icon(
+              showCompleted ? Icons.check_circle : Icons.check_circle_outline,
+              color: Colors.black,
+            ),
+            label: const Text(
+              'Show Completed',
+              style: TextStyle(color: Colors.black),
+            ),
+          ),
+        ],
       ),
       body: ListView.builder(
         restorationId: 'sampleItemListView',
-        itemCount: widget.items.length,
+        itemCount: displayedItems.length,
         itemBuilder: (BuildContext context, int index) {
-          final item = widget.items[index];
+          final item = displayedItems[index];
 
           return BudgetItem(
-              item: item, onDeleteItem: widget.onDeleteItem, cam: widget.cam);
+              item: item, 
+              onDeleteItem: widget.onDeleteItem, 
+              onCompleteItem: widget.onCompleteItem,
+              cam: widget.cam);
         },
       ),
       //Changed floatingActionButton to persistentFooterButtons in order to have a delete button next to the add button

--- a/budget_buddy/lib/widgets/budget_item.dart
+++ b/budget_buddy/lib/widgets/budget_item.dart
@@ -11,10 +11,12 @@ class BudgetItem extends StatelessWidget {
       {super.key,
       required this.item,
       required this.onDeleteItem,
+      required this.onCompleteItem,
       required this.cam});
 
   final Item item;
   final ItemsListDeletedCallback onDeleteItem;
+  final Function(Item) onCompleteItem;
   final cam;
 
   @override
@@ -28,15 +30,31 @@ class BudgetItem extends StatelessWidget {
       pictureBool = "Image Attached";
     }
     String fo = fmf.output.symbolOnLeft;
-    String freq = item.frequency!;
+    String freq = item.frequency ?? "One Time";
     return ListTile(
-        title: Text(item.name),
-        leading: const CircleAvatar(
+        title: Text(
+          item.name,
+          style: TextStyle(
+            decoration: item.isComplete ? TextDecoration.lineThrough : null,
+          ),
+        ),
+        leading: CircleAvatar(
           // This might be the picture of the item
-          backgroundColor: Colors.green,
+          backgroundColor: item.isComplete ? Colors.grey : item.date!.isBefore(DateTime.now()) ? Colors.red : Colors.green,
         ),
         subtitle: Text(
-            "${DateFormat('MM-dd-yy').format(item.date!)} | $fo | $freq | $pictureBool"),
+          "${DateFormat('MM-dd-yy').format(item.date!)} | $fo | $freq | $pictureBool${item.isComplete ? " | Completed" : ""}"
+        ),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (!item.isComplete)
+              IconButton(
+                icon: const Icon(Icons.check_circle_outline),
+                onPressed: () => onCompleteItem(item),
+              ),
+          ],
+        ),
         onTap: () {
           //open a dialog box
           showDialog(


### PR DESCRIPTION
In order to make frequency page less busy, I made it to where only the most urgent occurrence of an item (the current due or the past due) will appear. The rest of the occurrences will not exist until those are completed. Completed functionality was not implemented, so I added that to the app as well. It was specified in the issue that there was a desire for it to be less cluttered by completing items, so I feel this is within the issue still. I made it so there is a completed filter for completed items to keep the list view less busy. I also changed the colors of the bill circles to match the status of the bill. Only creating the items when they were the next one due made the calendar view page a bit wonky. To fix this, I created a function called getFutureOccurrences() that would display the dot on the calendar to show an item is due that day without having to create the next year's worth of bills to do so.